### PR TITLE
 Update ha-blueprint-linked-entities.yaml to better prevent self-triggering

### DIFF
--- a/ha-blueprint-linked-entities.yaml
+++ b/ha-blueprint-linked-entities.yaml
@@ -4,7 +4,7 @@ blueprint:
 
     [![Open your Home Assistant instance and show the blueprint import dialog with a specific blueprint pre-filled.](https://my.home-assistant.io/badges/blueprint_import.svg)](https://my.home-assistant.io/redirect/blueprint_import/?blueprint_url=https%3A%2F%2Fraw.githubusercontent.com%2Falexdelprete%2Fha-blueprints%2Fmain%2Fha-blueprint-linked-entities.yaml)
 
-    **Linked Entities v1.2** 🔛
+    **Linked Entities v1.3** 🔛
 
     This blueprint allows you to easily create/maintain an automation that links the state of multiple entities:
       - turn ANY linked entity ON, it will turn ON ALL linked entities.
@@ -23,6 +23,9 @@ blueprint:
     I'm sure you'll find many more use-cases. :slight_smile:
 
     **CHANGELOG:**
+      - 1.3: (2024-07-10)
+        - Ignore changes to entities triggered by this automation
+        - Do not change the state of the entity triggering the automation
       - 1.2: (2024-01-28 - thanks @phrak / @TimU for the PR)
         - Changed the action to a "Choose" building block to support fan, light and future attributes
         - Added support for linked fan speeds
@@ -51,6 +54,16 @@ blueprint:
       selector:
         entity:
           multiple: true
+    delay_miliseconds:
+      name: Delay
+      description: How long to delay changes to linked entities
+      selector:
+        number:
+          min: 0
+          max: 1000
+          unit_of_measurement: miliseconds
+          mode: box
+      default: 200
 
 mode: single
 max_exceeded: silent
@@ -82,6 +95,10 @@ trigger:
     entity_id: !input linked_entity
     attribute: color_temp
 
+condition:
+  - condition: template
+    value_template: "{{ trigger.to_state.context.id != this.context.id }}"
+
 action:
   - choose:
       - conditions:
@@ -90,18 +107,18 @@ action:
         sequence:
           - service: "homeassistant.turn_on"
             target:
-              entity_id: !input linked_entity
+              entity_id: "{{linked_entities | reject('eq', trigger.entity_id) | list }}"
           - delay:
-              milliseconds: 200
+              milliseconds: !input delay_miliseconds
       - conditions:
           - condition: trigger
             id: turn_off
         sequence:
           - service: "homeassistant.turn_off"
             target:
-              entity_id: !input linked_entity
+              entity_id: "{{linked_entities | reject('eq', trigger.entity_id) | list }}"
           - delay:
-              milliseconds: 200
+              milliseconds: !input delay_miliseconds
       - conditions:
           - condition: trigger
             id: set_speed
@@ -110,10 +127,10 @@ action:
               set_fan_speed: "{{ trigger.to_state.attributes.percentage }}"
           - service: fan.set_percentage
             data:
-              entity_id: !input linked_entity
+              entity_id: "{{linked_entities | reject('eq', trigger.entity_id) | list }}"
               percentage: "{{ set_fan_speed }}"
           - delay:
-              milliseconds: 200
+              milliseconds: !input delay_miliseconds
       - conditions:
           - condition: trigger
             id: set_brightness
@@ -122,10 +139,10 @@ action:
               set_light_brightness: "{{ trigger.to_state.attributes.brightness }}"
           - service: light.turn_on
             data:
-              entity_id: !input linked_entity
+              entity_id: "{{linked_entities | reject('eq', trigger.entity_id) | list }}"
               brightness: "{{ set_light_brightness }}"
           - delay:
-              milliseconds: 200
+              milliseconds: !input delay_miliseconds
       - conditions:
           - condition: trigger
             id: set_color_temp
@@ -134,7 +151,7 @@ action:
               set_light_color_temp: "{{ trigger.to_state.attributes.color_temp }}"
           - service: light.turn_on
             data:
-              entity_id: !input linked_entity
+              entity_id: "{{linked_entities | reject('eq', trigger.entity_id) | list }}"
               color_temp: "{{ set_light_color_temp }}"
           - delay:
-              milliseconds: 200
+              milliseconds: !input delay_miliseconds


### PR DESCRIPTION
My little contribution:

Version 1.3: (2024-07-10)
- Ignore changes to entities triggered by this automation
- Do not change the state of the entity triggering the automation

I have dimmers that triggered the automation for every step in their "dimming", which in turn was basically "resetting" the dimmer to its previous value. 

This fixes that :)