### PR TITLE
Ensure that brightness value is honored at turn on

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![Open your Home Assistant instance and show the blueprint import dialog with a specific blueprint pre-filled.](https://my.home-assistant.io/badges/blueprint_import.svg)](https://my.home-assistant.io/redirect/blueprint_import/?blueprint_url=https%3A%2F%2Fraw.githubusercontent.com%2Falexdelprete%2Fha-blueprints%2Fmain%2Fha-blueprint-linked-entities.yaml)
 
-**Linked Entities v1.3** 🔛
+**Linked Entities v1.4** 🔛
 
 This blueprint allows you to easily create/maintain an automation that links the state of multiple entities:
   - turn ANY linked entity ON, it will turn ON ALL linked entities.
@@ -19,6 +19,8 @@ My main use-case was for multiple light switches in the house controlling the sa
 I'm sure you'll find many more use-cases. :slight_smile:
 
 **CHANGELOG:**
+  - **1.4**: (2025-05-10)
+    - Include set brightness when turning on a light - this will be ignored if the target entity does not have brightness
   - **1.3**: (2024-07-10 - thanks @jsenecal for PR #2)
     - Ignore changes to entities triggered by this automation
     - Do not change the state of the entity triggering the automation

--- a/ha-blueprint-linked-entities.yaml
+++ b/ha-blueprint-linked-entities.yaml
@@ -4,7 +4,7 @@ blueprint:
 
     [![Open your Home Assistant instance and show the blueprint import dialog with a specific blueprint pre-filled.](https://my.home-assistant.io/badges/blueprint_import.svg)](https://my.home-assistant.io/redirect/blueprint_import/?blueprint_url=https%3A%2F%2Fraw.githubusercontent.com%2Falexdelprete%2Fha-blueprints%2Fmain%2Fha-blueprint-linked-entities.yaml)
 
-    **Linked Entities v1.3** 🔛
+    **Linked Entities v1.4** 🔛
 
     This blueprint allows you to easily create/maintain an automation that links the state of multiple entities:
       - turn ANY linked entity ON, it will turn ON ALL linked entities.
@@ -23,6 +23,8 @@ blueprint:
     I'm sure you'll find many more use-cases. :slight_smile:
 
     **CHANGELOG:**
+      - 1.4: (2025-05-10)
+        - Include set brightness when turning on a light - this will be ignored if the target entity does not have brightness
       - 1.3: (2024-07-10 - thanks @jsenecal for PR #2)
         - Ignore changes to entities triggered by this automation
         - Do not change the state of the entity triggering the automation
@@ -105,17 +107,20 @@ action:
           - condition: trigger
             id: turn_on
         sequence:
-          - service: "homeassistant.turn_on"
-            target:
+          - variables:
+              set_light_brightness: "{{ trigger.to_state.attributes.brightness }}"
+          - service: light.turn_on
+            data:
               entity_id: "{{linked_entities | reject('eq', trigger.entity_id) | list }}"
+              brightness: "{{ set_light_brightness }}"
           - delay:
               milliseconds: !input delay_miliseconds
       - conditions:
           - condition: trigger
             id: turn_off
         sequence:
-          - service: "homeassistant.turn_off"
-            target:
+          - service: "light.turn_off"
+            data:
               entity_id: "{{linked_entities | reject('eq', trigger.entity_id) | list }}"
           - delay:
               milliseconds: !input delay_miliseconds


### PR DESCRIPTION
Using "homeassistant.turn_on" does not support brightness.

I changed it to `light.turn_on` to add support for brightness. I'm not sure if this breaks what this was initially intended for. I feel like the name "linked entities" is  more generic and adding support for brightness to it wasn't really appropriate. Perhaps, the proper name for a separate version of this is "linked lights." The reason I bring this up is because I think by switching from `homeassistent.turn_on` to `light.turn_on`, you can no longer keep `switches` in sync.

If `alexdelprete` feels this fundamentally changes the usage of `linked entities`, I have cloned this and renamed it to `linked-lights`: https://github.com/jnrcorp/ha-blueprints/tree/main/linked-lights

Additionally, I think we can easily add `set_light_color_temp: "{{ trigger.to_state.attributes.color_temp }}"` under the `variables` of `turn_on` and `color_temp: "{{ set_light_color_temp }}"` under `data`. I don't have any color temp control bulbs to test this out, though.